### PR TITLE
Add advanced Firecrawl search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # omp-extended-search
 
-Extra search tools for the [omp](https://omp.sh) coding agent. omp's built-in `web_search` covers everyday lookups; these tools add backends it exposes poorly or not at all. Each tool is one self-contained TypeScript file — no build step, no dependencies, survives omp upgrades.
+Extra search tools for the [omp](https://omp.sh) coding agent. omp's built-in `web_search` covers everyday lookups; these tools add backends or advanced controls it exposes poorly or not at all. Each tool is one self-contained TypeScript file — no build step, no dependencies, survives omp upgrades.
 
 Install only the ones you want.
 
@@ -14,6 +14,7 @@ Install only the ones you want.
 | Product Hunt | `tools/producthunt_search.ts` | Recent/top launches by topic and date (the v2 API has no keyword search — it lists, it doesn't grep). | `PRODUCTHUNT_API_TOKEN` (Developer Token from the free app page — not the API Key) |
 | X Search | `tools/x_search.ts` | Searches public posts on X (Twitter) via xAI's native search. Keyword, semantic, user, and thread search; can optionally resolve each cited post to its real text and engagement numbers. | `/login` → xAI Grok (SuperGrok or X Premium+), or `XAI_API_KEY` |
 | Exa Search | `tools/exa_search.ts` | Full Exa API: search types (`auto` / `fast` / `neural` / `deep`), vertical categories (papers, people, companies, github), domain/date filters, answer-with-citations, URL contents fetch. omp's native Exa path only ever uses `auto` + summary. | `/login` → Exa, or `EXA_API_KEY` |
+| Firecrawl Search | `tools/firecrawl_search.ts` | Direct Firecrawl Search API with web/news/images sources, GitHub/research/PDF categories, domain/date/location filters, highlights, optional page scraping, and raw response metadata. omp 17.0.9+ can use Firecrawl behind ordinary `web_search` when Firecrawl is explicitly selected in `providers.webSearchOrder`; this extension is the advanced/direct lane. | Credential order: omp session/provider Firecrawl credential first; `FIRECRAWL_API_KEY` second; keyless access last (limited). Either credential provides higher limits. |
 | Parallel Search | `tools/parallel_search.ts` | Full Parallel V1 API: search modes (`turbo` / `basic` / `advanced`) with objective + multi-query support, URL extract, and deep-research task processors (`lite` … `ultra8x`). omp's native path hardcodes the old beta `fast` mode. | `/login` → Parallel, or `PARALLEL_API_KEY` |
 
 ## Install
@@ -25,6 +26,7 @@ cd omp-extended-search
 ./install.sh hackernews feed arxiv   # the free, no-key tools
 ./install.sh x                      # just X search
 ./install.sh exa parallel           # just Exa and Parallel
+./install.sh firecrawl              # advanced/direct Firecrawl controls
 ./install.sh reddit                 # just Reddit
 ./install.sh all                    # everything
 ./install.sh                        # prints help, installs nothing
@@ -54,6 +56,7 @@ Just ask — the model should pick the tool from your wording:
 - "What launched on Product Hunt this week?"
 - "What's being said on X about the latest omp release?"
 - "Use exa for search: recent papers on agent memory"
+- "Use Firecrawl news search for this week and return highlights"
 - "Use parallel for search: compare agent memory backends"
 - "Use your normal web search and expand with Exa and Parallel"
 
@@ -84,23 +87,32 @@ write xd://reddit_search
 
 write xd://x_search
 {"query":"omp agent","focus":"relevance","recency":"week","limit":10}
+
+write xd://firecrawl_search
+{"query":"agent memory","sources":["news"],"recency":"week","limit":5}
 ```
 
 **Common failure mode:** writing to `xdi://…` or a bare filename creates a
 normal file/directory in the workspace and **never runs the tool**. Always use
 the exact prefix **`xd://`** plus the tool name (`hackernews_search`,
-`x_search`, …).
+`firecrawl_search`, `x_search`, …).
 
 Built-in `web_search` may still appear as a native tool *or* as `xd://web_search`
 depending on omp version — prefer whatever the session already exposes; do not
-invent a third URI.
+invent a third URI. Since omp 17.0.9, that built-in lane can use Firecrawl,
+including limited keyless access, **only when Firecrawl is explicitly selected
+in `providers.webSearchOrder`**. The automatic provider chain remains
+credential-gated, and this installer does not set provider order. Keep built-in
+`web_search` as the everyday default; invoke `xd://firecrawl_search` only when
+you need Firecrawl-specific sources, categories, filters, scrape controls, or
+raw Firecrawl metadata.
 
 ## How it works with omp
 
 1. **Install** the tool files into `~/.omp/agent/tools/` (or a project `.omp/tools/`).
 2. **Restart omp** — it picks up new tool files and mounts them under `xd://<name>`.
    Sanity check: `read xd://hackernews_search` (or another installed tool) returns a schema.
-3. **Built-in `web_search` stays the default** for everyday lookups. These tools add lanes omp covers poorly or not at all (X, HN, Reddit, PH, arXiv, feeds, full Exa/Parallel, GitHub discovery). You can mix them: “use normal web search and also check HN + Reddit.”
+3. **Built-in `web_search` stays the default** for everyday lookups. omp 17.0.9+ can back it with Firecrawl when explicitly configured in `providers.webSearchOrder`; this installer leaves that order unchanged. These tools add lanes or controls omp covers poorly or not at all (X, HN, Reddit, PH, arXiv, feeds, advanced/direct Firecrawl, full Exa/Parallel, GitHub discovery). You can mix them: “use normal web search and also check HN + Reddit.”
 4. **Optional plan-first gate** — with the global confirm rule installed, the agent does **not** fire searches immediately. It proposes which sources to use, how to structure each request, and waits for your OK — one rule over web_search and every extended tool (including X). After approval, it invokes via `write` to `xd://…` as above.
 
 ## Optional: confirm-before-search gate
@@ -113,7 +125,7 @@ Settings change cost, latency, and which corner of the internet you hit. If you'
 ./install.sh all --with-gate
 ```
 
-That installs one global recommend-first **agent rule** ([rules/omp-search-confirm.md](rules/omp-search-confirm.md)) covering built-in `web_search` and every extended tool (HN, Reddit, PH, GitHub, arXiv, feeds, X, Exa, Parallel).
+That installs one global recommend-first **agent rule** ([rules/omp-search-confirm.md](rules/omp-search-confirm.md)) covering built-in `web_search` and every extended tool (HN, Reddit, PH, GitHub, arXiv, feeds, X, Firecrawl, Exa, Parallel).
 
 **Intended UX:** the model proposes sources + parameters in the chat and waits for your “go” / tweaks. It is **not** a per-call “Approve x_search?” popup. Keep `tools.approvalMode: yolo` (omp default for many setups) or per-tool `allow` so tools run quietly after you approve the plan in chat. Only set a tool to `prompt` if you *want* a hard UI dialog every call. Say “just search” anytime to skip the chat gate for one request.
 
@@ -127,6 +139,7 @@ That installs one global recommend-first **agent rule** ([rules/omp-search-confi
 - [docs/producthunt.md](docs/producthunt.md) — token setup and parameters
 - [docs/x.md](docs/x.md) — x_search settings: focus, reasoning effort, date windows, handle filters, post capture
 - [docs/exa.md](docs/exa.md) — exa_search settings: types, contents packing, categories, filters, answer, contents
+- [docs/firecrawl.md](docs/firecrawl.md) — firecrawl_search sources, categories, filters, highlights, optional scraping, costs, and raw response shape
 - [docs/parallel.md](docs/parallel.md) — parallel_search settings: modes, extract, task processors
 
 ### Agent rule (plan-first gate)
@@ -138,5 +151,5 @@ Install into omp with `./install.sh … --with-confirm-rule` (copies it to `~/.o
 ## Notes
 
 - `x_search` used to live at [omp-x-search](https://github.com/bnivanov/omp-x-search). That repo is archived; this one is its home now.
-- Auth resolution in every tool: omp session credentials first, environment variables as fallback.
+- `firecrawl_search` resolves credentials in this order: omp session/provider Firecrawl credential, `FIRECRAWL_API_KEY`, then limited keyless access.
 - License: [MIT](./LICENSE)

--- a/docs/firecrawl.md
+++ b/docs/firecrawl.md
@@ -1,0 +1,118 @@
+# firecrawl_search
+
+Direct access to Firecrawl's `POST https://api.firecrawl.dev/v2/search` endpoint. The extension is the **advanced/direct Firecrawl lane**: omp's built-in `web_search` remains the everyday choice.
+
+Since omp 17.0.9, native `web_search` can itself use Firecrawl, including limited keyless access, **only when Firecrawl is explicitly selected in `providers.webSearchOrder`**. The automatic provider chain remains credential-gated, and this installer does not set provider order. That native lane overlaps the basic `query` + `limit` case. `xd://firecrawl_search` remains useful when you need to choose Firecrawl explicitly or use its web/news/images sources, GitHub/research/PDF categories, domain/date/location filters, highlights and scrape controls, or raw response metadata.
+
+## Credentials
+
+Credential resolution order:
+
+1. The omp session/provider Firecrawl credential.
+2. `FIRECRAWL_API_KEY`.
+3. Keyless Firecrawl access.
+
+Keyless search is limited; either credential can provide higher limits. The tool sends `Authorization: Bearer …` when either the stored session/provider credential or `FIRECRAWL_API_KEY` is selected, without exposing the credential.
+
+## July 22, 2026 highlights upgrade
+
+Firecrawl's July 22, 2026 Search upgrade changed the relevance model without changing the API. Existing searches now receive query-relevant highlights by default: a web result's `description` or a news result's `snippet` is a focused, Markdown-capable excerpt rather than merely the search engine's generic text. If Firecrawl cannot retrieve a page, it can fall back to the ordinary snippet while allowing the other results to complete. Image results are unchanged.
+
+Firecrawl reports **94.7% on SimpleQA** and **10x fewer tokens** than a traditional search-then-scrape workflow for this upgrade; those are Firecrawl's claims, not independent benchmarks.
+
+## Parameters
+
+User-facing keys are `snake_case`; the tool translates them to Firecrawl's `camelCase` payload keys.
+
+| Input | Default | Meaning / Firecrawl payload |
+|---|---|---|
+| `query` | required | Search query, at most 500 characters. |
+| `limit` | `10` | Results **per source**, 1–100. |
+| `sources` | `["web"]` | Any of `web`, `news`, `images`. Sent as `sources`. |
+| `categories` | omitted | Any of `github`, `research`, `pdf`. Sent as `categories`. |
+| `include_domains` | omitted | Hostnames to include; sent as `includeDomains`. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | omitted | Hostnames to exclude; sent as `excludeDomains`. Mutually exclusive with `include_domains`. |
+| `recency` | omitted | Convenience value `hour`, `day`, `week`, `month`, or `year`; maps to `tbs=qdr:h`, `qdr:d`, `qdr:w`, `qdr:m`, or `qdr:y`. |
+| `tbs` | omitted | Raw Firecrawl/Google time filter, including `qdr:*`, `sbd:1`, or a custom `cdr` date range. It applies to web search only. |
+| `location` | omitted | Free-form location bias. Firecrawl recommends pairing it with `country`. |
+| `country` | `US` upstream | Two-letter country bias; omitted by the tool unless supplied. |
+| `highlights` | `true` | Enables query-relevant web descriptions and news snippets. Images are unaffected. |
+| `content` | `none` | `none`, `markdown`, `summary`, or `links`. Any value other than `none` requests that full-page scrape format through `scrapeOptions.formats`. |
+| `only_main_content` | omitted | Optional `scrapeOptions.onlyMainContent`; Firecrawl applies its upstream default. Used only with scraped content. |
+| `max_age_ms` | omitted | Optional cache age in milliseconds; maps to `scrapeOptions.maxAge`. |
+| `timeout_ms` | `60000` | Whole search timeout in milliseconds; maps to top-level `timeout`. |
+| `scrape_timeout_ms` | omitted | Optional per-page scrape timeout in milliseconds; maps to `scrapeOptions.timeout`. Firecrawl's upstream default is 60 seconds and accepted range is 1–300 seconds. |
+| `ignore_invalid_urls` | omitted | Maps to top-level `ignoreInvalidURLs`; Firecrawl applies its upstream default when omitted. Controls whether invalid result URLs are skipped. |
+
+`recency` is the convenient choice for common windows; use `tbs` for Firecrawl's raw time syntax. They are mutually exclusive. Categories select Firecrawl vertical indexes, while sources select result kinds. Do not assume that a `limit` of 10 means 10 total results: with `sources: ["web", "news"]`, it can return up to 10 of each.
+
+## Highlights versus full scrape content
+
+The default is deliberately **highlights-only metadata**:
+
+```json
+{"query":"agent memory","highlights":true,"content":"none"}
+```
+
+That returns URLs, titles, focused descriptions/snippets, and other search metadata without asking Firecrawl to scrape every result page. This is usually the best agent input: focused text, lower latency, and no per-page scrape charge.
+
+Set `content` to `markdown`, `summary`, or `links` only when the result pages themselves are required. That builds `scrapeOptions.formats` and may add the requested field to each successfully scraped item. `only_main_content`, `max_age_ms`, and `scrape_timeout_ms` tune those scrapes. With `content: "none"`, the tool emits no `scrapeOptions` and ignores those three scrape-only inputs. A page scrape can fail while the rest of the search succeeds; keep the item's error instead of discarding the whole response.
+
+## Result shape
+
+The visible tool output renders grouped Web, News, and Images sections and shows `warning`, `id`, `creditsUsed`, requested content, and partial item errors when present. The complete Firecrawl response remains available as `details.rawResponse`, preserving this upstream shape:
+
+```json
+{
+  "success": true,
+  "data": {
+    "web": [{"url":"…","title":"…","description":"…"}],
+    "news": [{"url":"…","title":"…","snippet":"…"}],
+    "images": [{"url":"…","title":"…"}]
+  },
+  "warning": "…",
+  "id": "…",
+  "creditsUsed": 4
+}
+```
+
+Only requested/non-empty source groups may be present. `warning`, `id`, and `creditsUsed` are preserved when Firecrawl returns them. Individual result entries may carry an error (for example, a scrape failure) while sibling entries remain usable. `details.request` also records the camelCase API body and whether authentication was keyless or `Bearer [REDACTED]`; it never exposes the key.
+
+There is **no pagination**: the endpoint exposes no cursor, page, offset, or next token. Choose a bounded `limit` and make another explicitly different query if needed.
+
+## Cost and latency
+
+- `limit` is per source. Selecting two sources can approximately double returned items and search credit use; three can triple them.
+- Firecrawl currently documents search at 2 credits per 10 results, rounded up **for each source**.
+- `content: "none"` avoids full-page scraping. Optional scraped `markdown`, `summary`, or `links` adds per-result scrape credits and network latency; PDFs can cost per PDF page, and premium scrape features may cost more.
+- Keyless mode is intentionally limited. A `FIRECRAWL_API_KEY` raises limits but does not make scraping free.
+- Search `timeout_ms` and per-page `scrape_timeout_ms` are separate. A larger timeout can improve completion but also increases worst-case latency.
+
+## Invocation
+
+These are exact xdev invocations: `read` the device for its live schema, then `write` JSON to the same **`xd://firecrawl_search`** path. There is no `xdi://` form and `firecrawl_search` is not a top-level function call.
+
+### Focused news highlights, keyless or keyed
+
+```text
+read  xd://firecrawl_search
+
+write xd://firecrawl_search
+{"query":"AI agent memory","sources":["news"],"recency":"week","limit":5}
+```
+
+### Firecrawl category and domain filters
+
+```text
+write xd://firecrawl_search
+{"query":"Model Context Protocol servers","categories":["github"],"include_domains":["github.com"],"limit":10}
+```
+
+### Multiple sources with optional page content
+
+```text
+write xd://firecrawl_search
+{"query":"agent evaluation benchmark","sources":["web","news"],"categories":["research"],"content":"summary","only_main_content":true,"scrape_timeout_ms":30000,"limit":5}
+```
+
+The last request allows up to five results **from each source** and asks Firecrawl to scrape a summary for each result, so plan for both search credits and additional scrape cost/latency. For an ordinary lookup with no Firecrawl-specific control, use omp's built-in `web_search` instead.

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,9 @@
 #
 #   ./install.sh x                  install x_search only
 #   ./install.sh exa parallel       install exa_search + parallel_search
+#
 #   ./install.sh hackernews feed    install the free, no-key tools
+#   ./install.sh firecrawl          install firecrawl_search only
 #   ./install.sh all                install every tool
 #
 # Opt-in extras (applied to the selected tools only):
@@ -36,6 +38,7 @@ Tools (pick one or more):
   reddit       reddit_search.ts      — Reddit via Arctic Shift archive (no key)
   github       github_search.ts      — GitHub repo search, trending/new projects
   producthunt  producthunt_search.ts — Product Hunt launches (Developer Token, not API Key)
+  firecrawl    firecrawl_search.ts   — advanced direct Firecrawl search (keyless limited mode; optional FIRECRAWL_API_KEY for higher limits)
   all          all of the above
 
 Extras (opt-in, applied to selected tools):
@@ -49,8 +52,8 @@ EOF
 
 for arg in "$@"; do
   case "$arg" in
-    x|exa|parallel|hackernews|feed|arxiv|reddit|github|producthunt) SELECTED+=("$arg") ;;
-    all) SELECTED=(x exa parallel hackernews feed arxiv reddit github producthunt) ;;
+    x|exa|parallel|hackernews|feed|arxiv|reddit|github|producthunt|firecrawl) SELECTED+=("$arg") ;;
+    all) SELECTED=(x exa parallel hackernews feed arxiv reddit github producthunt firecrawl) ;;
     --with-confirm-rule) WITH_CONFIRM_RULE=1 ;;
     --with-approval-gate) WITH_APPROVAL_GATE=1 ;;
     --with-gate)
@@ -176,6 +179,7 @@ echo "  1. Credentials for the tools you installed:"
 wants x           && echo "       X:            /login → xAI Grok (SuperGrok or X Premium+)  or  export XAI_API_KEY=..."
 wants exa         && echo "       Exa:          /login → Exa  or  export EXA_API_KEY=..."
 wants parallel    && echo "       Parallel:     /login → Parallel  or  export PARALLEL_API_KEY=..."
+wants firecrawl  && echo "       Firecrawl:    keyless limited mode; export FIRECRAWL_API_KEY=... for higher limits"
 wants hackernews  && echo "       Hacker News:  none needed"
 wants feed        && echo "       Feeds:        none needed"
 wants arxiv       && echo "       arXiv:        none needed"
@@ -183,12 +187,13 @@ wants reddit      && echo "       Reddit:       none needed (Arctic Shift archiv
 wants github      && echo "       GitHub:       works without auth (low rate limit); export GITHUB_TOKEN=... or gh auth login for more"
 wants producthunt && echo "       Product Hunt: app at producthunt.com/v2/oauth/applications → export PRODUCTHUNT_API_TOKEN=<Developer Token, not API Key>"
 echo "  2. Restart any open omp session so the new tools are discovered under xd://."
-echo "     Sanity check: read xd://<tool>_search  (e.g. xd://hackernews_search) → schema."
+echo "     Sanity check: read xd://<tool>_search (e.g. xd://hackernews_search or xd://firecrawl_search) → schema."
 echo "     Invoke:       write JSON args to that same xd:// path (NOT xdi://, NOT a bare file)."
 echo "  3. Ask in chat, e.g.:"
 wants x           && echo "       \"what's being said on X about ...\""
 wants exa         && echo "       \"use exa for search: ...\""
 wants parallel    && echo "       \"use parallel for search: ...\""
+wants firecrawl  && echo "       \"use firecrawl for advanced direct search: ...\""
 wants hackernews  && echo "       \"search hacker news for ...\" / \"what's on the front page of HN?\""
 wants feed        && echo "       \"check the ai-labs feeds for ...\""
 wants arxiv       && echo "       \"find recent arxiv papers on ...\""
@@ -203,4 +208,4 @@ if [[ "$WITH_CONFIRM_RULE" -eq 0 && "$WITH_APPROVAL_GATE" -eq 0 ]]; then
 fi
 echo
 echo "Docs: docs/x.md, docs/exa.md, docs/parallel.md, docs/hackernews.md, docs/feed.md,"
-echo "      docs/arxiv.md, docs/reddit.md, docs/github.md, docs/producthunt.md"
+echo "      docs/arxiv.md, docs/reddit.md, docs/github.md, docs/producthunt.md, docs/firecrawl.md"

--- a/rules/omp-search-confirm.md
+++ b/rules/omp-search-confirm.md
@@ -8,7 +8,7 @@ alwaysApply: true
 
 When the user asks for something that needs **live outside research** — web facts, news, social chatter, papers, launches, repos, feeds, comparisons, multi-source synthesis — **do not call** research tools immediately.
 
-That includes: built-in `web_search`, and any installed extended tool (`exa_search`, `parallel_search`, `x_search`, `hackernews_search`, `reddit_search`, `producthunt_search`, `github_search`, `arxiv_search`, `feed_search`).
+That includes: built-in `web_search`, and any installed extended tool (`firecrawl_search`, `exa_search`, `parallel_search`, `x_search`, `hackernews_search`, `reddit_search`, `producthunt_search`, `github_search`, `arxiv_search`, `feed_search`).
 
 Instead, use **this session's main model** (you) to propose a plan first, then wait.
 
@@ -21,7 +21,7 @@ They are **not** top-level function calls and there is **no `xdi://` scheme**.
 - Run: `write` JSON args to the same `xd://<tool_name>` path; the write result is the output
 - Wrong prefix (`xdi://`, bare path, inventing a filename) creates a workspace file and does **not** run the tool
 
-Built-in `web_search` may be native or `xd://web_search` depending on omp version — use what the session exposes. When the plan is approved, call tools with the agreed settings via that path.
+Built-in `web_search` may be native or `xd://web_search` depending on omp version — use what the session exposes. omp 17.0.9+ can use Firecrawl, including limited keyless access, behind that ordinary lane **only when Firecrawl is explicitly selected in `providers.webSearchOrder`**. The automatic provider chain remains credential-gated, and this installer does not set provider order. This does not make `firecrawl_search` the default. When the plan is approved, call tools with the agreed settings via the exposed path.
 
 ## 1. Restate the goal
 
@@ -34,6 +34,7 @@ Pick **one** primary path, or an explicit combination. Prefer the cheapest path 
 | Need | Prefer | Why |
 |---|---|---|
 | Quick fact / docs / obvious query | **`web_search` alone** | Fast, already configured; no extra spend |
+| Firecrawl-specific web/news/images sources, GitHub/research/PDF categories, domain/date/location filters, optional page scrape, or raw Firecrawl metadata | **`firecrawl_search`** | Direct access to advanced Firecrawl controls the native lane does not expose |
 | Semantic “pages like this”, verticals (papers/people/companies/github), multi-angle SERP | **`exa_search`** | Neural/deep + categories beat generic SERP |
 | Objective + multi-query with long excerpts | **`parallel_search` search** | Long excerpts for synthesis |
 | Known URLs need body text | **`exa_search` contents** or **`parallel_search` extract** | Dedicated fetch |
@@ -55,6 +56,16 @@ For each tool you plan to call, list the resolved settings and a **one-clause re
 
 ### If using `web_search`
 - note provider preference if known; otherwise “session default”
+
+### If using `firecrawl_search`
+- Use only for Firecrawl-specific sources/categories/filters/scrape controls or raw provider metadata; ordinary lookups stay on built-in `web_search`. omp 17.0.9+ uses Firecrawl underneath only when configured in `providers.webSearchOrder`
+- `query` (required), `limit` (default `10`, range 1–100 **per source**), `sources` (`web` default; optional `news`/`images`), and optional `categories` (`github`/`research`/`pdf`)
+- Filters when useful: mutually exclusive `include_domains`/`exclude_domains`; `recency` (`hour`/`day`/`week`/`month`/`year`) or raw Firecrawl `tbs`; `location` and `country`
+- `highlights` defaults `true` for focused web descriptions/news snippets; `content` defaults `none` (no full-page scrape), or request `markdown`/`summary`/`links`
+- Scrape controls only when `content` is not `none`: `only_main_content`, `max_age_ms`, `scrape_timeout_ms`; `ignore_invalid_urls` is a top-level search option
+- `timeout_ms` defaults to `60000`. There is no pagination; choose one bounded request
+- Authentication resolves omp's stored Firecrawl/provider session credential first, then `FIRECRAWL_API_KEY`, then limited keyless mode; either authenticated source raises limits. Warn that multi-source `limit` applies independently to each source, search credits round up per source, and optional per-result scraping adds credits and latency
+- Expect grouped `web`/`news`/`images` data plus optional `warning`, `id`, and `creditsUsed`; retain partial item errors rather than treating one scrape failure as total failure
 
 ### If using `exa_search`
 - `operation`: `search` | `answer` | `contents`
@@ -107,6 +118,7 @@ For each tool you plan to call, list the resolved settings and a **one-clause re
 ### Cost / latency snapshot
 Order-of-magnitude is fine:
 - web_search / HN / reddit / github / arxiv / feeds / Product Hunt: free or already-provisioned / seconds
+- firecrawl_search: keyless is limited; search costs credits per source, and optional full-page scraping adds per-result credits + latency
 - exa auto+summary: ~$0.01 / few seconds; deep higher
 - parallel turbo/basic/advanced: ~$0.001–0.005 / sub-second–few seconds
 - parallel task lite/base/core: cents–tens of cents / tens of seconds+

--- a/tools/firecrawl_search.ts
+++ b/tools/firecrawl_search.ts
@@ -1,0 +1,409 @@
+/**
+ * Runtime custom tool: firecrawl_search
+ *
+ * Direct access to Firecrawl's advanced Search v2 filters and optional
+ * per-result content extraction. Generic searches should keep using omp's
+ * built-in web_search tool.
+ *
+ * Auth is optional: OMP's native Firecrawl provider credentials or
+ * FIRECRAWL_API_KEY enable authenticated usage, while limited keyless mode remains available.
+ */
+
+import type { CustomToolFactoryHost } from "@oh-my-pi/pi-coding-agent";
+
+const DEFAULT_BASE_URL = "https://api.firecrawl.dev";
+const DEFAULT_LIMIT = 10;
+const DEFAULT_TIMEOUT_MS = 60000;
+const MAX_SNIPPET = 1600;
+const MAX_RENDERED_CONTENT = 5000;
+const RECENCY_TBS = {
+	hour: "qdr:h",
+	day: "qdr:d",
+	week: "qdr:w",
+	month: "qdr:m",
+	year: "qdr:y",
+};
+
+function asString(value) {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function displayValue(value) {
+	if (typeof value === "string") return value;
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function compactText(value, max = MAX_SNIPPET) {
+	const text = asString(value);
+	if (!text) return undefined;
+	const compact = text.replace(/\s+/g, " ").trim();
+	return compact.length > max ? `${compact.slice(0, max)}…` : compact;
+}
+
+
+function buildSearchBody(params) {
+	const content = params.content || "none";
+	const timeoutMs = params.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+	const sources = params.sources?.length ? params.sources : ["web"];
+	const body = {
+		query: params.query,
+		limit: params.limit ?? DEFAULT_LIMIT,
+		sources,
+		highlights: params.highlights ?? true,
+		timeout: timeoutMs,
+	};
+
+	if (params.categories?.length) body.categories = params.categories;
+	if (params.include_domains?.length) body.includeDomains = params.include_domains;
+	if (params.exclude_domains?.length) body.excludeDomains = params.exclude_domains;
+
+	const tbs = asString(params.tbs) || RECENCY_TBS[params.recency];
+	if (tbs) body.tbs = tbs;
+	if (asString(params.location)) body.location = params.location.trim();
+	if (asString(params.country)) body.country = params.country.trim();
+	if (params.ignore_invalid_urls != null) body.ignoreInvalidURLs = params.ignore_invalid_urls;
+
+	if (content !== "none") {
+		const scrapeOptions = { formats: [content] };
+		if (params.only_main_content != null) scrapeOptions.onlyMainContent = params.only_main_content;
+		if (params.max_age_ms != null) scrapeOptions.maxAge = params.max_age_ms;
+		if (params.scrape_timeout_ms != null) scrapeOptions.timeout = params.scrape_timeout_ms;
+		body.scrapeOptions = scrapeOptions;
+	}
+
+	return { body, content, timeoutMs, sources };
+}
+
+
+async function resolveFirecrawlAuth(ctx) {
+	const authStorage = ctx?.modelRegistry?.authStorage;
+	const sessionId = ctx?.sessionManager?.getSessionId?.();
+	if (authStorage && typeof authStorage.getApiKey === "function") {
+		try {
+			const key = await authStorage.getApiKey("firecrawl", sessionId);
+			if (key) return { token: key, authMode: "session" };
+		} catch {
+			// Fall through to environment or keyless mode, matching other tools.
+		}
+	}
+	const key = asString(process.env.FIRECRAWL_API_KEY);
+	if (key) return { token: key, authMode: "env" };
+	return { token: undefined, authMode: "keyless" };
+}
+
+function apiErrorDetail(data, fallbackText) {
+	const code = asString(data?.code) || asString(data?.error?.code);
+	const errorValue = data?.error ?? data?.message ?? data?.detail;
+	const message = errorValue != null ? displayValue(errorValue) : asString(fallbackText) || "Request failed";
+	return { code, message };
+}
+
+function statusGuidance(status) {
+	if (status === 401) {
+		return "Authenticate the native Firecrawl provider or set FIRECRAWL_API_KEY; this request may require authenticated access rather than limited keyless mode.";
+	}
+	if (status === 402) return "Add Firecrawl credits or review the account's billing and plan limits.";
+	if (status === 429) return "Firecrawl rate-limited the request; retry later or reduce the result limit.";
+	return undefined;
+}
+
+async function fetchSearch(url, apiKey, body, signals, apiTimeoutMs) {
+	const controller = new AbortController();
+	const externalSignals = [...new Set(signals.filter(Boolean))];
+	const listeners = [];
+
+	for (const externalSignal of externalSignals) {
+		const onAbort = () => {
+			const error = new Error("Firecrawl request aborted");
+			error.name = "AbortError";
+			controller.abort(error);
+		};
+		if (externalSignal.aborted) {
+			onAbort();
+		} else {
+			externalSignal.addEventListener("abort", onAbort, { once: true });
+			listeners.push([externalSignal, onAbort]);
+		}
+	}
+
+	const graceMs = Math.min(5000, Math.max(1000, Math.ceil(apiTimeoutMs * 0.1)));
+	const clientTimeoutMs = apiTimeoutMs + graceMs;
+	const timer = setTimeout(() => {
+		const error = new Error(`Firecrawl request timed out after ${clientTimeoutMs}ms`);
+		error.name = "TimeoutError";
+		controller.abort(error);
+	}, clientTimeoutMs);
+
+	const headers = { "Content-Type": "application/json" };
+	if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+	try {
+		const response = await globalThis.fetch(url, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+			signal: controller.signal,
+		});
+		const text = await response.text();
+		let data;
+		try {
+			data = text ? JSON.parse(text) : {};
+		} catch {
+			data = { raw: text };
+		}
+
+		if (!response.ok || data?.success === false) {
+			const detail = apiErrorDetail(data, text);
+			const guidance = statusGuidance(response.status);
+			const code = detail.code ? `, code ${detail.code}` : "";
+			throw new Error(
+				`Firecrawl API error (HTTP ${response.status}${code}): ${detail.message}${guidance ? ` Guidance: ${guidance}` : ""}`,
+			);
+		}
+		return data;
+	} finally {
+		clearTimeout(timer);
+		for (const [externalSignal, onAbort] of listeners) {
+			externalSignal.removeEventListener("abort", onAbort);
+		}
+	}
+}
+
+function normalizeGroups(response) {
+	const payload = response?.data ?? response;
+	if (Array.isArray(payload)) return { web: payload, news: [], images: [] };
+	if (!payload || typeof payload !== "object") return { web: [], news: [], images: [] };
+	return {
+		web: Array.isArray(payload.web) ? payload.web : [],
+		news: Array.isArray(payload.news) ? payload.news : [],
+		images: Array.isArray(payload.images) ? payload.images : [],
+	};
+}
+
+function itemError(item) {
+	if (item?.error == null) return undefined;
+	return compactText(displayValue(item.error), 800);
+}
+
+function renderRequestedContent(item, content) {
+	if (content === "none") return [];
+	if (content === "links") {
+		const links = Array.isArray(item?.links) ? item.links : [];
+		if (!links.length) return [];
+		const lines = ["", "Content (links):"];
+		for (const link of links.slice(0, 30)) {
+			const url = asString(link) || asString(link?.url) || asString(link?.href);
+			if (url) lines.push(`- ${url}`);
+		}
+		if (links.length > 30) lines.push(`- … ${links.length - 30} more link(s) in raw response`);
+		return lines;
+	}
+
+	const value = asString(item?.[content]);
+	if (!value) return [];
+	const wasTruncated = value.length > MAX_RENDERED_CONTENT;
+	const rendered = value.slice(0, MAX_RENDERED_CONTENT);
+	const quoted = rendered.split(/\r?\n/).map((line) => (line ? `> ${line}` : ">"));
+	const lines = ["", `Content (${content}):`, "", ...quoted];
+	if (wasTruncated) lines.push("", "… truncated; full content is in details.rawResponse");
+	return lines;
+}
+
+function renderWebOrNewsItem(item, index, kind, content) {
+	const title = asString(item?.title) || asString(item?.url) || "Untitled";
+	const lines = [`### ${index + 1}. ${title}`];
+	if (asString(item?.url)) lines.push(`URL: ${item.url}`);
+	if (kind === "news" && asString(item?.date)) lines.push(`Date: ${item.date}`);
+	if (kind === "news" && asString(item?.imageUrl)) lines.push(`Image: ${item.imageUrl}`);
+
+	const snippet = compactText(kind === "news" ? item?.snippet ?? item?.description : item?.description ?? item?.snippet);
+	if (snippet) lines.push("", snippet);
+	const error = itemError(item);
+	if (error) lines.push("", `Item error: ${error}`);
+	lines.push(...renderRequestedContent(item, content));
+	return lines;
+}
+
+function renderImageItem(item, index) {
+	const title = asString(item?.title) || asString(item?.url) || asString(item?.imageUrl) || "Untitled image";
+	const lines = [`### ${index + 1}. ${title}`];
+	if (asString(item?.url)) lines.push(`Source URL: ${item.url}`);
+	if (asString(item?.imageUrl)) lines.push(`Image URL: ${item.imageUrl}`);
+	if (item?.imageWidth != null || item?.imageHeight != null) {
+		lines.push(`Dimensions: ${item.imageWidth ?? "?"} × ${item.imageHeight ?? "?"}`);
+	}
+	const error = itemError(item);
+	if (error) lines.push(`Item error: ${error}`);
+	return lines;
+}
+
+function formatResults(response, content, requestedSources) {
+	const groups = normalizeGroups(response);
+	const lines = ["# Firecrawl advanced search"];
+	const warning = response?.warning ?? response?.data?.warning;
+	const id = response?.id ?? response?.data?.id;
+	const creditsUsed = response?.creditsUsed ?? response?.data?.creditsUsed;
+	if (warning != null) lines.push(`Warning: ${displayValue(warning)}`);
+	if (id != null) lines.push(`Job ID: ${displayValue(id)}`);
+	if (creditsUsed != null) lines.push(`Credits used: ${displayValue(creditsUsed)}`);
+
+	const presentSources = ["web", "news", "images"].filter(
+		(source) => requestedSources.includes(source) || groups[source].length > 0,
+	);
+	const sections = presentSources.length ? presentSources : ["web"];
+
+	for (const source of sections) {
+		const items = groups[source];
+		lines.push("", `## ${source[0].toUpperCase()}${source.slice(1)} (${items.length})`);
+		if (!items.length) {
+			lines.push("No results.");
+			continue;
+		}
+		for (let index = 0; index < items.length; index += 1) {
+			lines.push("");
+			lines.push(
+				...(source === "images"
+					? renderImageItem(items[index], index)
+					: renderWebOrNewsItem(items[index], index, source, content)),
+			);
+		}
+	}
+	return lines.join("\n").trimEnd();
+}
+
+const factory = (host: CustomToolFactoryHost) => {
+	const z = host.zod;
+	const parameters = z
+		.object({
+			query: z.string().trim().min(1).max(500).describe("Search query (required, maximum 500 characters)."),
+			limit: z.number().int().min(1).max(100).optional().describe("Results per source (default 10, maximum 100)."),
+			sources: z
+				.array(z.enum(["web", "news", "images"]))
+				.min(1)
+				.optional()
+				.describe("Firecrawl result sources (default: web)."),
+			categories: z
+				.array(z.enum(["github", "research", "pdf"]))
+				.min(1)
+				.optional()
+				.describe("Optional Firecrawl vertical categories."),
+			include_domains: z.array(z.string().trim().min(1)).optional().describe("Only return results from these domains."),
+			exclude_domains: z.array(z.string().trim().min(1)).optional().describe("Exclude results from these domains."),
+			tbs: z
+				.string()
+				.trim()
+				.min(1)
+				.optional()
+				.describe("Advanced Firecrawl/Google time filter, e.g. qdr:d or a custom date range."),
+			recency: z
+				.enum(["hour", "day", "week", "month", "year"])
+				.optional()
+				.describe("Convenience time filter mapped to qdr:h/d/w/m/y; mutually exclusive with tbs."),
+			location: z.string().trim().min(1).optional().describe("Search location bias, e.g. Germany or San Francisco, California."),
+			country: z.string().trim().min(2).max(2).optional().describe("Two-letter country code bias, e.g. US."),
+			highlights: z.boolean().optional().describe("Return highlighted search snippets (default true)."),
+			content: z
+				.enum(["none", "markdown", "summary", "links"])
+				.optional()
+				.describe("Optional per-result extraction format. none (default) avoids full-page scraping."),
+			only_main_content: z.boolean().optional().describe("When extracting content, omit page chrome and other non-main content."),
+			max_age_ms: z.number().int().min(0).optional().describe("Maximum cache age in milliseconds for extracted content."),
+			timeout_ms: z.number().int().positive().optional().describe("Search API timeout in milliseconds (default 60000)."),
+			scrape_timeout_ms: z
+				.number()
+				.int()
+				.min(1000)
+				.max(300000)
+				.optional()
+				.describe("Per-result scrape timeout in milliseconds (1000–300000)."),
+			ignore_invalid_urls: z.boolean().optional().describe("Ignore invalid result URLs instead of failing the search."),
+		})
+		.superRefine((params, validation) => {
+			if (params.include_domains?.length && params.exclude_domains?.length) {
+				validation.addIssue({
+					code: "custom",
+					path: ["exclude_domains"],
+					message: "include_domains and exclude_domains are mutually exclusive",
+				});
+			}
+			if (params.tbs && params.recency) {
+				validation.addIssue({
+					code: "custom",
+					path: ["recency"],
+					message: "tbs and recency are mutually exclusive",
+				});
+			}
+		});
+
+	return {
+		name: "firecrawl_search",
+		label: "Firecrawl Advanced Search",
+		approval: "read",
+		description: [
+			"Direct advanced Firecrawl Search v2 access; this is not the everyday web-search default.",
+			"Keep using built-in web_search for ordinary queries.",
+			"Use firecrawl_search when Firecrawl-specific source/category, domain, time, location, cache, timeout, or optional extraction controls are needed.",
+			"Defaults to web results with highlighted metadata only and does not scrape full-page content unless content is markdown, summary, or links.",
+			"Supports limited keyless mode; native Firecrawl provider credentials or FIRECRAWL_API_KEY enable authenticated requests.",
+		].join(" "),
+		parameters,
+
+		formatApprovalDetails(args) {
+			const params = args || {};
+			const sources = params.sources?.length ? params.sources : ["web"];
+			const content = params.content || "none";
+			const lines = [
+				`Query: ${params.query ?? "(none)"}`,
+				`Sources: ${sources.join(", ")}  |  Limit: ${params.limit ?? DEFAULT_LIMIT} per source`,
+				`Highlights: ${params.highlights === false ? "off" : "on"}  |  Content: ${content}`,
+				`Search timeout: ${params.timeout_ms ?? DEFAULT_TIMEOUT_MS}ms`,
+			];
+			if (params.categories?.length) lines.push(`Categories: ${params.categories.join(", ")}`);
+			if (params.include_domains?.length) lines.push(`Include domains: ${params.include_domains.join(", ")}`);
+			if (params.exclude_domains?.length) lines.push(`Exclude domains: ${params.exclude_domains.join(", ")}`);
+			if (params.tbs || params.recency) lines.push(`Time filter: ${params.tbs || RECENCY_TBS[params.recency]}`);
+			if (params.location) lines.push(`Location: ${params.location}`);
+			if (params.country) lines.push(`Country: ${params.country}`);
+			return lines;
+		},
+
+		async execute(_toolCallId, params, onUpdate, ctx, signal) {
+			try {
+				const { body, content, timeoutMs, sources } = buildSearchBody(params);
+				const auth = await resolveFirecrawlAuth(ctx);
+				const baseUrl = (asString(process.env.FIRECRAWL_BASE_URL) || DEFAULT_BASE_URL).replace(/\/+$/, "");
+				const url = `${baseUrl}/v2/search`;
+				onUpdate?.({
+					content: [{ type: "text", text: "Firecrawl advanced search…" }],
+					details: { phase: "start", provider: "firecrawl", authenticated: Boolean(auth.token), authMode: auth.authMode },
+				});
+
+				const rawResponse = await fetchSearch(url, auth.token, body, [signal, ctx?.signal], timeoutMs);
+				return {
+					content: [{ type: "text", text: formatResults(rawResponse, content, sources) }],
+					details: {
+						request: {
+							provider: "firecrawl",
+							operation: "search",
+							method: "POST",
+							url,
+							authentication: auth.token ? `Bearer [REDACTED] (${auth.authMode})` : "none (keyless)",
+							body,
+						},
+						rawResponse,
+					},
+				};
+			} catch (error) {
+				if (error && (error.name === "AbortError" || error.name === "TimeoutError")) throw error;
+				const message = error instanceof Error ? error.message : String(error);
+				return { isError: true, content: [{ type: "text", text: `Error: ${message}` }] };
+			}
+		},
+	};
+};
+
+export default factory;


### PR DESCRIPTION
Adds an authenticated/keyless Firecrawl v2 search device with advanced sources, categories, filters, highlights, optional scrape formats, installer integration, and documentation. Verified on OMP 17.1.1 with mocked edge cases, full Bun builds, isolated installer smoke, independent review, and a live authenticated API request.